### PR TITLE
added fixq/update for bad questions

### DIFF
--- a/model.js
+++ b/model.js
@@ -50,6 +50,7 @@ exports.Entry = sequelize.define("entry", {
     "status": Sequelize.INTEGER,  //0: on queue, 1: being helped, 2: helped
     "question": Sequelize.STRING,
     "cooldown_override": Sequelize.BOOLEAN,
+    "blocked": Sequelize.BOOLEAN //True: cannot be helped, False: can be helped
 }, {
     timestamps: false,
     underscored: true

--- a/realtime.js
+++ b/realtime.js
@@ -91,6 +91,30 @@ exports.help = function(entry_id, ta) {
     });
 };
 
+exports.fixq = function(entry_id) {
+    exports.seq = exports.seq + 1;
+    if(!sio) {
+        console.log("ERROR: Socket.io is not initialized yet");
+        return;
+    }
+    sio.emit("fixq", {
+        seq: exports.seq,
+        id: entry_id
+    });
+};
+
+exports.update = function(entry_id) {
+    exports.seq = exports.seq + 1;
+    if(!sio) {
+        console.log("ERROR: Socket.io is not initialized yet");
+        return;
+    }
+    sio.emit("update", {
+        seq: exports.seq,
+        id: entry_id
+    });
+};
+
 exports.cancel = function(entry_id, ta_id) {
     exports.seq = exports.seq + 1;
     if (!sio) {

--- a/static/js/client.js
+++ b/static/js/client.js
@@ -126,6 +126,8 @@ function buildTAEntry(entry) {
             if (!entry.blocked) {
                 elt.find(".help-button").removeClass("hide");
                 elt.find(".fix-question-button").removeClass("hide");
+            } else {
+                elt.find(".helping-text").text("Student is updating question");
             }
         } else {
             elt.find(".remove-button").removeClass("hide");
@@ -296,11 +298,7 @@ socket.on("fixq", function(message) {
     $("#queue li").each(function(index, item) {
         if ($(item).data("entryId") == message.id) {
             $(item).find("button").addClass("hide");
-            if (ta_id && !ta_helping_id) {
-                $(item).find(".remove-button").removeClass("hide");
-                $(item).find(".helping-text").text("Student is updating question");
-            }
-            
+
             if ($(item).hasClass("me")) {
                 $(item).find(".remove-button").removeClass("hide");
                 $(item).find(".helping-text").text("Please update your question");

--- a/static/js/client.js
+++ b/static/js/client.js
@@ -331,6 +331,7 @@ socket.on("update", function(message) {
                 $(item).find(".remove-button").removeClass("hide");
                 $(item).find(".help-button").removeClass("hide");
                 $(item).find(".fix-question-button").removeClass("hide");
+                $(item).find(".helping-text").text("");
             } 
         }
     });

--- a/views/home.ejs
+++ b/views/home.ejs
@@ -163,7 +163,8 @@ $(document).ready(function() {
         ta_full_name: entry.TA ? entry.TA.full_name : "",
         question: entry.question,
         cooldown_override: entry.cooldown_override,
-	}).replace(/<\//g, "<\\/"); %>));
+        blocked: entry.blocked
+  }).replace(/<\//g, "<\\/"); %>));
   <%_ } else { _%>
     $("#queue").append(buildStudentEntry(<%- JSON.stringify({
         id: entry.id,


### PR DESCRIPTION
fixes #2 
To test this, you must reset your database since a new 'blocked' field has been added.

Added block field to entries
Does not have update question functionality
Student receives notif when TA hits fix question button, which blocks student from being helped until they hit the update question button. They will still move up in the queue as entries above finish.
<img width="1036" alt="Screen Shot 2020-12-28 at 9 43 00 PM" src="https://user-images.githubusercontent.com/29640871/103261399-4ba43580-4956-11eb-82dc-07922790e3bf.png">
<img width="338" alt="Screen Shot 2020-12-28 at 9 43 36 PM" src="https://user-images.githubusercontent.com/29640871/103261402-4f37bc80-4956-11eb-87d2-7dbfbb933cdf.png">
<img width="942" alt="Screen Shot 2020-12-28 at 9 48 38 PM" src="https://user-images.githubusercontent.com/29640871/103261449-78584d00-4956-11eb-8628-b8cd784cfcde.png">
<img width="1034" alt="Screen Shot 2020-12-28 at 9 55 00 PM" src="https://user-images.githubusercontent.com/29640871/103261719-58755900-4957-11eb-81e8-5ce4384e05be.png">
