### PR TITLE
Update Question Modal

### DIFF
--- a/realtime.js
+++ b/realtime.js
@@ -109,7 +109,7 @@ exports.update = function(entry_id) {
         console.log("ERROR: Socket.io is not initialized yet");
         return;
     }
-    sio.emit("update", {
+    sio.emit("update-question", {
         seq: exports.seq,
         id: entry_id
     });

--- a/routes/home.js
+++ b/routes/home.js
@@ -420,6 +420,8 @@ function post_fixq(req, res) {
 
 function post_update(req, res) {
     var id = req.body.entry_id;
+    var updatedQuestion = req.body.question;
+
     model.sql.transaction(function(t) {
         return model.Entry.findByPk(id, {
             transaction: t,
@@ -433,6 +435,7 @@ function post_update(req, res) {
             }
             return entry.update({
                 blocked: false,
+                question: updatedQuestion
             }, {transaction: t});
         })
     }).then(function(result) {

--- a/routes/home.js
+++ b/routes/home.js
@@ -455,7 +455,7 @@ exports.post = function(req, res) {
         case "CANCEL": post_cancel(req, res); break;
         case "DONE": post_done(req, res); break;
         case "FIXQ": post_fixq(req, res); break;
-        case "UPDATE": post_update(req, res); break;
+        case "UPDATE-QUESTION": post_update(req, res); break;
         default:
             respond(req, res, "Invalid action: " + action);
     }

--- a/routes/home.js
+++ b/routes/home.js
@@ -385,8 +385,6 @@ function post_done(req, res) {
     });
 }
 
-//TODO: Add/edit functions to support updateQ popup
-
 function post_fixq(req, res) {
     var id = req.body.entry_id;
     model.sql.transaction(function(t) {
@@ -420,7 +418,7 @@ function post_fixq(req, res) {
 
 function post_update(req, res) {
     var id = req.body.entry_id;
-    var updatedQuestion = req.body.question;
+    var updated_question = req.body.question;
 
     model.sql.transaction(function(t) {
         return model.Entry.findByPk(id, {
@@ -435,7 +433,7 @@ function post_update(req, res) {
             }
             return entry.update({
                 blocked: false,
-                question: updatedQuestion
+                question: updated_question
             }, {transaction: t});
         })
     }).then(function(result) {

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -39,21 +39,6 @@ input {
     outline: 0px;
 }
 
-textarea {
-    margin: 0px;
-    border: none;
-    outline: none;
-    width: 500px;
-    height: auto;
-    color: inherit;
-    border-bottom: 1px solid #9e9e9e;
-}
-
-textarea:focus {
-    border-bottom: 1px solid #26a69a;
-    box-shadow: 0 1px 0 0 #26a69a;
-}
-
 #message {
     margin: 20px 0;
 }

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -39,6 +39,21 @@ input {
     outline: 0px;
 }
 
+textarea {
+    margin: 0px;
+    border: none;
+    outline: none;
+    width: 500px;
+    height: auto;
+    color: inherit;
+    border-bottom: 1px solid #9e9e9e;
+}
+
+textarea:focus {
+    border-bottom: 1px solid #26a69a;
+    box-shadow: 0 1px 0 0 #26a69a;
+}
+
 #message {
     margin: 20px 0;
 }

--- a/static/js/client.js
+++ b/static/js/client.js
@@ -307,7 +307,6 @@ socket.on("add", function(message) {
     updateStatus();
 });
 
-//TODO: UPDATE MODAL STUFFS
 socket.on("fixq", function(message) {
     if (disable_updates) return;
     checkAndUpdateSeq(message.seq);
@@ -342,15 +341,18 @@ socket.on("fixq", function(message) {
 socket.on("update-question", function(message) {
     if (disable_updates) return;
     checkAndUpdateSeq(message.seq);
-    
+
+    if (ta_id) { // A student's question is updated, reload
+        window.location.reload();
+        return;
+    }
+
     $("#queue li").each(function(index, item) {
         if ($(item).data("entryId") == message.id) {
             $(item).find("button").addClass("hide");
             if ($(item).hasClass("me")) {
                 $(item).find(".remove-button").removeClass("hide");
-            } else if (ta_id) {
-                window.location.reload();
-            } 
+            }
         }
     });
 });

--- a/static/js/client.js
+++ b/static/js/client.js
@@ -85,7 +85,9 @@ $(document).ready(function() {
     });
 
     $(document).on("click", ".open-update-question-button", function(event) {
-        M.Modal.getInstance($("#update_question_modal")).open();
+        var elt = $("#update_question_modal");
+        elt.find(".id-input").val($("#queue").find(".me").data("entryId"));
+        M.Modal.getInstance(elt).open();
         event.preventDefault();
     });
 
@@ -160,6 +162,9 @@ function buildMyEntry(entry) {
     if (entry.status == 1) {
         elt.find(".helping-text").text(entry.ta_full_name + " is helping");
     } else {
+        if (entry.blocked) {
+            elt.find(".open-update-question-button").removeClass("hide");
+        }
         elt.find(".remove-button").removeClass("hide");
     }
     return elt;

--- a/static/js/client.js
+++ b/static/js/client.js
@@ -340,7 +340,6 @@ socket.on("fixq", function(message) {
 });
 
 socket.on("update-question", function(message) {
-    console.log("update-question emitted");
     if (disable_updates) return;
     checkAndUpdateSeq(message.seq);
     
@@ -349,11 +348,8 @@ socket.on("update-question", function(message) {
             $(item).find("button").addClass("hide");
             if ($(item).hasClass("me")) {
                 $(item).find(".remove-button").removeClass("hide");
-            } else if (ta_id && !ta_helping_id) {
-                $(item).find(".remove-button").removeClass("hide");
-                $(item).find(".help-button").removeClass("hide");
-                $(item).find(".fix-question-button").removeClass("hide");
-                $(item).find(".helping-text").text("");
+            } else if (ta_id) {
+                window.location.reload();
             } 
         }
     });

--- a/static/js/client.js
+++ b/static/js/client.js
@@ -3,7 +3,7 @@ const cancelHtml = "<button class='entry-item cancel-button hide waves-effect wa
 const fixqHtml = "<button class='entry-item fix-question-button hide waves-effect waves btn-flat grey lighten-2 grey-text text-darken-3' name='action' value='FIXQ'><i class='fas fa-edit'></i></button>";
 const doneHtml = "<button class='entry-item done-button hide waves-effect waves-light btn blue' name='action' value='DONE'>Done</button>";
 const helpHtml = "<button class='entry-item help-button hide waves-effect waves-light btn blue' name='action' value='HELP'>Help</button>";
-const updateHtml = "<button class='entry-item update-question-button hide waves-effect waves btn-flat grey lighten-2 grey-text text-darken-3' name='action' value='UPDATE'>Update Question</button>";
+const updateHtml = "<button class='entry-item update-question-button hide waves-effect waves btn-flat grey lighten-2 grey-text text-darken-3' name='action' value='UPDATE-QUESTION'>Update Question</button>";
 
 const entryHtml = `
     <li class='collection-item'>
@@ -321,13 +321,17 @@ socket.on("fixq", function(message) {
                     console.log("There was an error showing a browser notification.");
                 }
 
-                M.Modal.getInstance($("#update_modal")).open();
+                M.Modal.getInstance($("#update_question_modal")).open();
             }
         }
     });
 });
 
-socket.on("update", function(message) {
+socket.on("open-update-question-modal", function(message) {
+    M.Modal.getInstance($("#update_question_modal")).open();
+});
+
+socket.on("update-question", function(message) {
     if (disable_updates) return;
     checkAndUpdateSeq(message.seq);
     

--- a/static/js/client.js
+++ b/static/js/client.js
@@ -326,7 +326,9 @@ socket.on("fixq", function(message) {
                     console.log("There was an error showing a browser notification.");
                 }
 
-                M.Modal.getInstance($("#update_question_modal")).open();
+                var elt = $("#update_question_modal");
+                elt.find(".id-input").val(message.id);
+                M.Modal.getInstance(elt).open();
             }
         }
     });

--- a/static/js/client.js
+++ b/static/js/client.js
@@ -335,6 +335,10 @@ socket.on("fixq", function(message) {
                 elt.find(".id-input").val(message.id);
                 M.Modal.getInstance(elt).open();
             }
+            else if (ta_id) {
+                $(item).find(".remove-button").removeClass("hide");
+                $(item).find(".helping-text").text("Student is updating question");
+            }
         }
     });
 });

--- a/static/js/client.js
+++ b/static/js/client.js
@@ -320,6 +320,8 @@ socket.on("fixq", function(message) {
                 } catch (error) {
                     console.log("There was an error showing a browser notification.");
                 }
+
+                M.Modal.getInstance($("#update_modal")).open();
             }
         }
     });

--- a/static/js/client.js
+++ b/static/js/client.js
@@ -104,6 +104,8 @@ $(document).ready(function() {
         disable_updates = true;
         submitAddForm(true);
     })
+
+    $('input#question, textarea#question').characterCounter();
 });
 
 

--- a/static/js/client.js
+++ b/static/js/client.js
@@ -3,7 +3,7 @@ const cancelHtml = "<button class='entry-item cancel-button hide waves-effect wa
 const fixqHtml = "<button class='entry-item fix-question-button hide waves-effect waves btn-flat grey lighten-2 grey-text text-darken-3' name='action' value='FIXQ'><i class='fas fa-edit'></i></button>";
 const doneHtml = "<button class='entry-item done-button hide waves-effect waves-light btn blue' name='action' value='DONE'>Done</button>";
 const helpHtml = "<button class='entry-item help-button hide waves-effect waves-light btn blue' name='action' value='HELP'>Help</button>";
-const updateHtml = "<button class='entry-item update-question-button hide waves-effect waves btn-flat grey lighten-2 grey-text text-darken-3' name='action' value='UPDATE-QUESTION'>Update Question</button>";
+const updateQuestionModalHtml = "<button class='entry-item open-update-question-button hide waves-effect waves btn-flat grey lighten-2 grey-text text-darken-3'>Update Question</button>";
 
 const entryHtml = `
     <li class='collection-item'>
@@ -18,7 +18,7 @@ const entryHtml = `
                 <div class='entry-item entry-spacer'></div>
                 <div class='entry-item entry-container entry-buttons'>
                     ${fixqHtml}
-                    ${updateHtml}
+                    ${updateQuestionModalHtml}
                     ${removeHtml}
                     ${helpHtml}
                     ${cancelHtml}
@@ -82,6 +82,11 @@ $(document).ready(function() {
     // Manages confirmation for fix question button
     $(document).on("click", ".fix-question-button", function(event) {
         // TODO: Pop up window to allow TA to fill out text to send to student
+    });
+
+    $(document).on("click", ".open-update-question-button", function(event) {
+        M.Modal.getInstance($("#update_question_modal")).open();
+        event.preventDefault();
     });
 
     mq = window.matchMedia("(min-width: 761px)");
@@ -309,7 +314,7 @@ socket.on("fixq", function(message) {
             if ($(item).hasClass("me")) {
                 $(item).find(".remove-button").removeClass("hide");
                 $(item).find(".helping-text").text("Please update your question");
-                $(item).find(".update-question-button").removeClass("hide");
+                $(item).find(".open-update-question-button").removeClass("hide");
 
                 try {
                     if (("Notification" in window) && (Notification.permission == "granted")) {
@@ -327,11 +332,8 @@ socket.on("fixq", function(message) {
     });
 });
 
-socket.on("open-update-question-modal", function(message) {
-    M.Modal.getInstance($("#update_question_modal")).open();
-});
-
 socket.on("update-question", function(message) {
+    console.log("update-question emitted");
     if (disable_updates) return;
     checkAndUpdateSeq(message.seq);
     

--- a/static/js/client.js
+++ b/static/js/client.js
@@ -3,7 +3,7 @@ const cancelHtml = "<button class='entry-item cancel-button hide waves-effect wa
 const fixqHtml = "<button class='entry-item fix-question-button hide waves-effect waves btn-flat grey lighten-2 grey-text text-darken-3' name='action' value='FIXQ'><i class='fas fa-edit'></i></button>";
 const doneHtml = "<button class='entry-item done-button hide waves-effect waves-light btn blue' name='action' value='DONE'>Done</button>";
 const helpHtml = "<button class='entry-item help-button hide waves-effect waves-light btn blue' name='action' value='HELP'>Help</button>";
-const updateQuestionModalHtml = "<button class='entry-item open-update-question-button hide waves-effect waves btn-flat grey lighten-2 grey-text text-darken-3'>Update Question</button>";
+const openUpdateQuestionModalHtml = "<button class='entry-item open-update-question-button hide waves-effect waves btn-flat grey lighten-2 grey-text text-darken-3'>Update Question</button>";
 
 const entryHtml = `
     <li class='collection-item'>
@@ -18,7 +18,7 @@ const entryHtml = `
                 <div class='entry-item entry-spacer'></div>
                 <div class='entry-item entry-container entry-buttons'>
                     ${fixqHtml}
-                    ${updateQuestionModalHtml}
+                    ${openUpdateQuestionModalHtml}
                     ${removeHtml}
                     ${helpHtml}
                     ${cancelHtml}

--- a/views/home.ejs
+++ b/views/home.ejs
@@ -107,7 +107,7 @@
 </div>
 
 
-<div id="update_modal" class="modal">
+<div id="update_question_modal" class="modal">
   <div class="modal-content center-align">
     <h4>Please update your question!</h4>
     <p>Before we can help you, we need a bit more details from you.<br><br> Especially for homework problems, we want to know <strong>what you've tried and/or already understand</strong> in addition to what you're looking for guidance on. Be sure to read the Diderot Guides to Success chapter "Asking Questions" for more on this.</p>

--- a/views/home.ejs
+++ b/views/home.ejs
@@ -110,7 +110,9 @@
 <div id="update_question_modal" class="modal">
   <div class="modal-content center-align">
     <h4>Please update your question!</h4>
-    <p>Before we can help you, we need a bit more details from you.<br><br> Especially for homework problems, we want to know <strong>what you've tried and/or already understand</strong> in addition to what you're looking for guidance on. Be sure to read the Diderot Guides to Success chapter "Asking Questions" for more on this.</p>
+    <p>Before we can help you, we need a bit more details from you.</p>
+    <p>Especially for homework problems, we want to know <strong>what you've tried and/or already understand</strong> in addition to what you're looking for guidance on. Be sure to read the Diderot Guides to Success chapter "Asking Questions" for more on this!</p>
+    <button class='waves-effect waves-light btn cyan' name='action' value='UPDATE-QUESTION'>Update Question</button>
   </div>
   <div class="modal-footer">
     <a href="javascript:;" class="modal-close waves-effect light-blue-text text-darken-1 btn-flat">Close</a>

--- a/views/home.ejs
+++ b/views/home.ejs
@@ -115,9 +115,9 @@
     <form method='POST'>
       <input type='hidden' class='id-input' name='entry_id'>
       <p>
-        <div class="input-field inline col l10 m10 s12">
-          <input id="question" name="question" type="text" minlength=3 required>
-          <label for="question">Question</label>
+        <div class="input-field inline col">
+          <textarea id="question" name="question" type="text" minlength=3 maxlength=255 rows=5 required></textarea>
+          <label for="question">Question (max 255 characters)</label>
         </div>
       </p>
       <button class='waves-effect waves-light btn cyan' name='action' value='UPDATE-QUESTION'>Update Question</button>

--- a/views/home.ejs
+++ b/views/home.ejs
@@ -71,7 +71,7 @@
     <label for="topic">What would you like help with?</label>
   </div>
   <div class="input-field inline col l10 m10 s12">
-      <input id="question" name="question" type="text" minlength=3 required>
+      <input id="question" name="question" type="text" minlength=3 maxlength=255 data-length="255" required>
       <label for="question">Question</label>
   </div>
   <div class="input-field inline col l2 m2 s12 center-btn">
@@ -114,12 +114,12 @@
     <p>Especially for homework problems, we want to know <strong>what you've tried and/or already understand</strong> in addition to what you're looking for guidance on. Be sure to read the Diderot Guides to Success chapter "Asking Questions" for more on this!</p>
     <form method='POST'>
       <input type='hidden' class='id-input' name='entry_id'>
-      <p>
-        <div class="input-field inline col">
-          <textarea id="question" name="question" type="text" minlength=3 maxlength=255 rows=5 required></textarea>
-          <label for="question">Question (max 255 characters)</label>
+        <div class="row">
+          <div class="input-field col l12 m12 s12">
+            <textarea id="question" name="question" type="text" minlength=3 maxlength=255 data-length="255" required class="materialize-textarea"></textarea>
+            <label for="question">Question (max 255 characters)</label>
+          </div>
         </div>
-      </p>
       <button class='waves-effect waves-light btn cyan' name='action' value='UPDATE-QUESTION'>Update Question</button>
     </form>
   </div>

--- a/views/home.ejs
+++ b/views/home.ejs
@@ -112,7 +112,10 @@
     <h4>Please update your question!</h4>
     <p>Before we can help you, we need a bit more details from you.</p>
     <p>Especially for homework problems, we want to know <strong>what you've tried and/or already understand</strong> in addition to what you're looking for guidance on. Be sure to read the Diderot Guides to Success chapter "Asking Questions" for more on this!</p>
-    <button class='waves-effect waves-light btn cyan' name='action' value='UPDATE-QUESTION'>Update Question</button>
+    <form method='POST'>
+      <input type='hidden' class='id-input' name='entry_id'>
+      <button class='waves-effect waves-light btn cyan' name='action' value='UPDATE-QUESTION'>Update Question</button>
+    </form>
   </div>
   <div class="modal-footer">
     <a href="javascript:;" class="modal-close waves-effect light-blue-text text-darken-1 btn-flat">Close</a>

--- a/views/home.ejs
+++ b/views/home.ejs
@@ -106,6 +106,17 @@
   </div>
 </div>
 
+
+<div id="update_modal" class="modal">
+  <div class="modal-content center-align">
+    <h4>Please update your question!</h4>
+    <p>Before we can help you, we need a bit more details from you.<br><br> Especially for homework problems, we want to know <strong>what you've tried and/or already understand</strong> in addition to what you're looking for guidance on. Be sure to read the Diderot Guides to Success chapter "Asking Questions" for more on this.</p>
+  </div>
+  <div class="modal-footer">
+    <a href="javascript:;" class="modal-close waves-effect light-blue-text text-darken-1 btn-flat">Close</a>
+  </div>
+</div>
+
 <script src="/socket.io/socket.io.js"></script>
 <script type="text/javascript" src="/js/client.js"></script>
 <script type="text/javascript">

--- a/views/home.ejs
+++ b/views/home.ejs
@@ -114,6 +114,12 @@
     <p>Especially for homework problems, we want to know <strong>what you've tried and/or already understand</strong> in addition to what you're looking for guidance on. Be sure to read the Diderot Guides to Success chapter "Asking Questions" for more on this!</p>
     <form method='POST'>
       <input type='hidden' class='id-input' name='entry_id'>
+      <p>
+        <div class="input-field inline col l10 m10 s12">
+          <input id="question" name="question" type="text" minlength=3 required>
+          <label for="question">Question</label>
+        </div>
+      </p>
       <button class='waves-effect waves-light btn cyan' name='action' value='UPDATE-QUESTION'>Update Question</button>
     </form>
   </div>


### PR DESCRIPTION
An update question modal pops up on the client side when requested by a TA. The modal pops up again when clicking "Update Question".

Currently, clicking "Update Question" within the modal doesn't do anything. You will have to remove the student and add them again to continue the flow. 

The next step is to fix `post_update` allowing for the student's ID to be passed through and reflecting that the question was updated on the TA end. This may require adaption of something like `buildTaEntry` or `buildStudentEntry` similar to how the `ADD` action is implemented. After that we can finally add a form to submit an updated question.

![image](https://user-images.githubusercontent.com/34123199/105226644-45a50d00-5b2e-11eb-809c-57e5b544cf3b.png)

Edit: The above is now fixed, you can now fully update your question in a text box.