### PR TITLE
Adding config for Diderot "Asking Questions" Guide

### DIFF
--- a/routes/home.js
+++ b/routes/home.js
@@ -70,6 +70,7 @@ exports.get = function(req, res) {
                     order: [['due_date', 'ASC']]
                 })
             }(),
+            guide_url: options.ask_question_guide_link(),
             frozen: options.frozen(),
             message: options.message()
         }).then(function(results) {
@@ -85,6 +86,7 @@ exports.get = function(req, res) {
                 entries: results.entries,
                 topics: results.topics,
                 seq: realtime.seq,
+                guide_url: results.guide_url,
                 frozen: results.frozen,
                 message: results.message,
                 waittimes: waittimes.get(),

--- a/routes/options.js
+++ b/routes/options.js
@@ -10,7 +10,7 @@ var config = require("../config.json");
 var allowed_tags = "<a><b><blockquote><code><del><dd><dl><dt><em><h1><h2><h3><h4><h5><h6><i><img><kbd><li><ol><p><pre><s><sup><sub><strong><strike><small><ul><br><hr>";
 
 var options_cache = {};
-var protected_keys = ["current_semester", "slack_webhook", "cooldown_time"];
+var protected_keys = ["current_semester", "slack_webhook", "ask_question_guide_link", "cooldown_time"];
 
 exports.get_string = function(key, default_value) {
     if (default_value === undefined) {
@@ -70,9 +70,12 @@ exports.current_semester = function() {
 exports.slack_webhook = function() {
     return exports.get_string("slack_webhook", "");
 };
+exports.ask_question_guide_link = function() {
+    return exports.get_string("ask_question_guide_link", "");
+};
 exports.cooldown_time = function() {
     return exports.get_number("cooldown_time", 0);
-}
+};
 
 exports.get = function(req, res) {
     if (req.query.key == "frozen") {
@@ -121,6 +124,8 @@ function validate(key, value) {
     } else if (key == "current_semester" && RegExp("^[SMNF][0-9][0-9]$").test(value)) {
         return value;
     } else if (key == "slack_webhook") {
+        return value;
+    } else if (key == "ask_question_guide_link") {
         return value;
     } else if (key == "cooldown_time" && parseFloat(value) >= 0) {
         return parseFloat(value).toString();
@@ -191,6 +196,8 @@ function post_prop_update(req, key, prev_value, value) {
     } else if (key == "slack_webhook") {
         waittimes.update_slack();
         return "Webhook URL updated";
+    } else if (key == "ask_question_guide_link") {
+        return "Fix Question URL updated";
     } else if (key == "cooldown_time") {
         if (parseFloat(prev_value) > 0 && parseFloat(value) > 0) {
             return "Cooldown warning time limit updated";

--- a/routes/settings.js
+++ b/routes/settings.js
@@ -29,6 +29,7 @@ exports.get = function(req, res) {
         current_semester = semester;
         return Sequelize.Promise.props({
             webhook_url: options.slack_webhook(),
+            ask_question_guide_link: options.ask_question_guide_link(),
             cooldown_time: options.cooldown_time(),
             topics: function() {
                 return model.Topic.findAll({
@@ -58,6 +59,7 @@ exports.get = function(req, res) {
             video_chat_url: (req.session.TA ? req.session.TA.video_chat_url : undefined),
             current_semester: current_semester,
             slack_webhook: results.webhook_url,
+            ask_question_guide_link: results.ask_question_guide_link,
             cooldown_time: results.cooldown_time,
             topics: results.topics,
             tas: results.tas,

--- a/views/home.ejs
+++ b/views/home.ejs
@@ -120,6 +120,7 @@
       "Asking Questions"
     <%_ } _%>
     chapter for more on this!</p>
+    <p>If you're having trouble with rewording your question, enter "Need help with question" in the box below to ask a TA for help.</p>
     <form method='POST'>
       <input type='hidden' class='id-input' name='entry_id'>
         <div class="row">

--- a/views/home.ejs
+++ b/views/home.ejs
@@ -110,8 +110,16 @@
 <div id="update_question_modal" class="modal">
   <div class="modal-content center-align">
     <h4>Please update your question!</h4>
-    <p>Before we can help you, we need a bit more details from you.</p>
-    <p>Especially for homework problems, we want to know <strong>what you've tried and/or already understand</strong> in addition to what you're looking for guidance on. Be sure to read the Diderot Guides to Success chapter "Asking Questions" for more on this!</p>
+    <p>Before we can help you, we'll need some more details from you.</p>
+    <p>Especially for homework problems, we want to know <strong>what you've tried and/or already understand</strong> in addition to what you're looking for guidance on. Be sure to read the Diderot Guides to Success 
+    <%_ if (guide_url) { _%>
+    <a id="guide_url" href="<%= guide_url %>" target="_blank">
+      "Asking Questions"
+    </a> 
+    <%_ } else { _%>
+      "Asking Questions"
+    <%_ } _%>
+    chapter for more on this!</p>
     <form method='POST'>
       <input type='hidden' class='id-input' name='entry_id'>
         <div class="row">

--- a/views/settings.ejs
+++ b/views/settings.ejs
@@ -56,6 +56,7 @@
             <button type="submit" class='btn waves-effect waves-light cyan'>Change</button>
             </div>
         </form>
+        <p>If you have a Slack team set up for your course, you can set up a Slack Incoming Webhook <a href="https://my.slack.com/services/new/incoming-webhook/" target="_blank">here</a>. Otherwise, you may leave this field empty.</p>
         <form action="/options" method="POST" class="row" style="margin-bottom: 0px;">
             <div class="input-field inline col m10 s12">
             <input type="url" name="slack_webhook" id="slack_webhook" value="<%= slack_webhook %>"><label for="slack_webhook">Slack Webhook URL</label>
@@ -64,7 +65,15 @@
             <button type="submit" class='btn waves-effect waves-light cyan'>Change</button>
             </div>
         </form>
-        <p>If you have a Slack team set up for your course, you can set up a Slack Incoming Webhook <a href="https://my.slack.com/services/new/incoming-webhook/" target="_blank">here</a>. Otherwise, you may leave this field empty.</p>
+        <p>This link will be displayed to students when asked to fix their question. If not needed, you may leave this field empty.</p>
+        <form action="/options" method="POST" class="row" style="margin-bottom: 0px;">
+            <div class="input-field inline col m10 s12">
+            <input type="url" name="ask_question_guide_link" id="ask_question_guide_link" value="<%= ask_question_guide_link %>"><label for="ask_question_guide_link">Diderot "Asking Questions" Guide URL</label>
+            </div>
+            <div class="input-field inline col m2 s12 center-btn">
+            <button type="submit" class='btn waves-effect waves-light cyan'>Change</button>
+            </div>
+        </form>
         <form action="/options" method="POST" class="row" style="margin-bottom: 0px;">
             <div class="row">
                 Cooldown Warning Time Limit, in minutes (Use 0 to disable):


### PR DESCRIPTION
Enables admin to configure a URL to the Diderot "Asking Questions" guide, which will be displayed to students when they are asked to fix their question

![image](https://user-images.githubusercontent.com/43687061/105251230-b9501580-5b40-11eb-835d-7e6586d94157.png)
![image](https://user-images.githubusercontent.com/43687061/105251273-c836c800-5b40-11eb-8f9c-023d7168071f.png)